### PR TITLE
[Task #335] Add sqflite database base code to introduce persistent storage.

### DIFF
--- a/cogniopenapp/lib/src/database/app_database.dart
+++ b/cogniopenapp/lib/src/database/app_database.dart
@@ -1,0 +1,77 @@
+import 'package:path/path.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:cogniopenapp/src/database/model/media.dart';
+import 'package:cogniopenapp/src/database/model/conversation.dart';
+import 'package:cogniopenapp/src/database/model/photo.dart';
+import 'package:cogniopenapp/src/database/model/video.dart'; // Import the Video model
+import 'package:cogniopenapp/src/database/app_database_seed_data.dart';
+
+class AppDatabase {
+  static final AppDatabase instance = AppDatabase._init();
+
+  static Database? _database;
+
+  AppDatabase._init();
+
+  Future<Database> get database async {
+    if (_database != null) return _database!;
+
+    _database = await _initDB('app.db');
+    return _database!;
+  }
+
+  Future<Database> _initDB(String filePath) async {
+    final dbPath = await getDatabasesPath();
+    final path = join(dbPath, filePath);
+
+    return await openDatabase(path, version: 1, onCreate: _createDB);
+  }
+
+  Future _createDB(Database db, int version) async {
+    const idType = 'INTEGER PRIMARY KEY AUTOINCREMENT';
+    const textType = 'TEXT NOT NULL';
+    const boolType = 'BOOLEAN NOT NULL';
+    const integerType = 'INTEGER NOT NULL';
+    const textNullableType = 'TEXT';
+
+    final mediaColumns = [
+      '${MediaFields.id} $idType',
+      '${MediaFields.title} $textNullableType',
+      '${MediaFields.description} $textNullableType',
+      '${MediaFields.tags} $textNullableType',
+      '${MediaFields.timestamp} $integerType',
+      '${MediaFields.fileName} $textType',
+      '${MediaFields.storageSize} $integerType',
+      '${MediaFields.isFavorited} $boolType',
+    ];
+
+    await db.execute('''
+      CREATE TABLE $tableConversations (
+        ${mediaColumns.join(',\n')},
+        ${ConversationFields.summary} $textType
+      )
+    ''');
+
+    await db.execute('''
+      CREATE TABLE $tablePhotos (
+        ${mediaColumns.join(',\n')}
+      )
+    ''');
+
+    await db.execute('''
+      CREATE TABLE $tableVideos (
+        ${mediaColumns.join(',\n')},
+        ${VideoFields.duration} $textType,
+        ${VideoFields.thumbnail} $textNullableType
+      )
+    ''');
+
+    final appDatabaseSeedData = AppDatabaseSeedData();
+    appDatabaseSeedData.insertAppDatabaseSeedData();
+  }
+
+  Future close() async {
+    final db = await instance.database;
+    db.close();
+  }
+}

--- a/cogniopenapp/lib/src/database/app_database_seed_data.dart
+++ b/cogniopenapp/lib/src/database/app_database_seed_data.dart
@@ -1,0 +1,126 @@
+import 'package:cogniopenapp/src/database/model/conversation.dart';
+import 'package:cogniopenapp/src/database/repository/conversation_repository.dart';
+import 'package:cogniopenapp/src/database/model/photo.dart';
+import 'package:cogniopenapp/src/database/repository/photo_repository.dart';
+import 'package:cogniopenapp/src/database/model/video.dart';
+import 'package:cogniopenapp/src/database/repository/video_repository.dart';
+
+class AppDatabaseSeedData {
+  void insertAppDatabaseSeedData() async {
+    await ConversationRepository.instance.create(conversation1);
+    await ConversationRepository.instance.create(conversation2);
+    await ConversationRepository.instance.create(conversation3);
+
+    await PhotoRepository.instance.create(photo1);
+    await PhotoRepository.instance.create(photo2);
+    await PhotoRepository.instance.create(photo3);
+
+    await VideoRepository.instance.create(video1);
+    await VideoRepository.instance.create(video2);
+    await VideoRepository.instance.create(video3);
+  }
+
+  /* App Database Seed Data */
+
+  // Conversations:
+
+  static final conversation1 = Conversation(
+    title: 'Conversation 1',
+    description: 'Conversation 1 description.',
+    tags: ['tag 1', 'tag 2', 'tag 5'],
+    timestamp: DateTime(2023, 10, 15, 11, 14),
+    fileName: 'conversation1.mp4',
+    storageSize: 150000,
+    isFavorited: false,
+    summary: 'Summary 1.',
+  );
+
+  static final conversation2 = Conversation(
+    title: 'Conversation 2',
+    description: 'Conversation 2 description.',
+    tags: ['tag3', 'tag7'],
+    timestamp: DateTime(2023, 10, 14, 9, 19),
+    fileName: 'conversation2.mp4',
+    storageSize: 250000,
+    isFavorited: true,
+    summary: 'Summary 2.',
+  );
+
+  static final conversation3 = Conversation(
+    title: 'Conversation 3',
+    description: 'Conversation 3 description.',
+    tags: [],
+    timestamp: DateTime(2023, 10, 13, 21, 09),
+    fileName: 'conversation3.mp4',
+    storageSize: 50000,
+    isFavorited: false,
+    summary: 'Summary 3.',
+  );
+
+  // Photos:
+
+  static final photo1 = Photo(
+    title: 'Photo 1',
+    description: 'Photo 1 description.',
+    tags: ['tag 1', 'tag 3', 'tag 5'],
+    timestamp: DateTime(2023, 10, 15, 11, 15),
+    fileName: 'photo1.png',
+    storageSize: 15000,
+    isFavorited: false,
+  );
+
+  static final photo2 = Photo(
+    title: 'Photo 2',
+    description: 'Photo 2 description.',
+    tags: ['tag3', 'tag6'],
+    timestamp: DateTime(2023, 10, 14, 9, 20),
+    fileName: 'photo2.png',
+    storageSize: 25000,
+    isFavorited: true,
+  );
+
+  static final photo3 = Photo(
+    title: 'Photo 3',
+    description: 'Photo 3 description.',
+    tags: [],
+    timestamp: DateTime(2023, 10, 13, 21, 10),
+    fileName: 'photo3.png',
+    storageSize: 5000,
+    isFavorited: false,
+  );
+
+  // Videos:
+
+  static final video1 = Video(
+      title: 'Video 1',
+      description: 'Video 1 description.',
+      tags: ['tag 1', 'tag 2', 'tag 3'],
+      timestamp: DateTime(2023, 10, 15, 12, 30),
+      fileName: 'video1.mp4',
+      storageSize: 1500000,
+      isFavorited: false,
+      duration: "3:05",
+      thumbnail: "Thumbnail_1");
+
+  static final video2 = Video(
+      title: 'Video 2',
+      description: 'Video 2 description.',
+      tags: ['tag2', 'tag4'],
+      timestamp: DateTime(2023, 10, 14, 9, 05),
+      fileName: 'video2.mp4',
+      storageSize: 2500000,
+      isFavorited: false,
+      duration: "4:05",
+      thumbnail: "Thumbnail_2");
+
+  static final video3 = Video(
+      title: 'Video 3',
+      description: 'Video 3 description.',
+      tags: [],
+      timestamp: DateTime(2023, 10, 13, 20, 45),
+      fileName: 'video3.mp4',
+      storageSize: 500000,
+      isFavorited: true,
+      duration: "5:05",
+      thumbnail: "Thumbnail_3");
+}

--- a/cogniopenapp/lib/src/database/model/conversation.dart
+++ b/cogniopenapp/lib/src/database/model/conversation.dart
@@ -1,0 +1,88 @@
+import 'package:cogniopenapp/src/database/model/media.dart';
+import 'package:cogniopenapp/src/database/model/media_type.dart';
+
+const String tableConversations = 'conversations';
+
+class ConversationFields extends MediaFields {
+  static final List<String> values = [
+    ...MediaFields.values,
+    summary,
+  ];
+
+  static const String summary = 'summary';
+}
+
+class Conversation extends Media {
+  final String? summary;
+
+  Conversation({
+    int? id,
+    String? title,
+    String? description,
+    List<String>? tags,
+    required DateTime timestamp,
+    required String fileName,
+    required int storageSize,
+    required bool isFavorited,
+    this.summary,
+  }) : super(
+          id: id,
+          mediaType: MediaType.conversation,
+          title: title,
+          description: description,
+          tags: tags,
+          timestamp: timestamp,
+          fileName: fileName,
+          storageSize: storageSize,
+          isFavorited: isFavorited,
+        );
+
+  @override
+  Conversation copy({
+    int? id,
+    String? title,
+    String? description,
+    List<String>? tags,
+    DateTime? timestamp,
+    String? fileName,
+    int? storageSize,
+    bool? isFavorited,
+    String? summary,
+  }) =>
+      Conversation(
+        id: id ?? this.id,
+        title: title ?? this.title,
+        description: description ?? this.description,
+        tags: tags ?? this.tags,
+        timestamp: timestamp ?? this.timestamp,
+        fileName: fileName ?? this.fileName,
+        storageSize: storageSize ?? this.storageSize,
+        isFavorited: isFavorited ?? this.isFavorited,
+        summary: summary ?? this.summary,
+      );
+
+  @override
+  Map<String, Object?> toJson() {
+    return {
+      ...super.toJson(),
+      ConversationFields.summary: summary,
+    };
+  }
+
+  @override
+  static Conversation fromJson(Map<String, Object?> json) {
+    return Conversation(
+      id: json[MediaFields.id] as int?,
+      title: json[MediaFields.title] as String?,
+      description: json[MediaFields.description] as String?,
+      tags: (json[MediaFields.tags] as String?)?.split(','),
+      timestamp: DateTime.fromMillisecondsSinceEpoch(
+          (json[MediaFields.timestamp] as int),
+          isUtc: true),
+      fileName: json[MediaFields.fileName] as String,
+      storageSize: json[MediaFields.storageSize] as int,
+      isFavorited: json[MediaFields.isFavorited] == 1,
+      summary: json[ConversationFields.summary] as String?,
+    );
+  }
+}

--- a/cogniopenapp/lib/src/database/model/media.dart
+++ b/cogniopenapp/lib/src/database/model/media.dart
@@ -1,0 +1,75 @@
+import 'package:cogniopenapp/src/database/model/media_type.dart';
+
+abstract class MediaFields {
+  static final List<String> values = [
+    id,
+    mediaType,
+    title,
+    description,
+    tags,
+    timestamp,
+    fileName,
+    storageSize,
+    isFavorited,
+  ];
+
+  static const String id = '_id';
+  static const String mediaType = 'mediaType';
+  static const String title = 'title';
+  static const String description = 'description';
+  static const String tags = 'tags';
+  static const String timestamp = 'timestamp';
+  static const String fileName = 'fileName';
+  static const String storageSize = 'storageSize';
+  static const String isFavorited = 'isFavorited';
+}
+
+abstract class Media {
+  final int? id;
+  final MediaType mediaType;
+  final String? title;
+  final String? description;
+  final List<String>? tags;
+  final DateTime timestamp;
+  final String fileName;
+  final int storageSize;
+  final bool isFavorited;
+
+  Media({
+    this.id,
+    required this.mediaType,
+    this.title,
+    this.description,
+    this.tags,
+    required this.timestamp,
+    required this.fileName,
+    required this.storageSize,
+    required this.isFavorited,
+  });
+
+  Media copy({
+    int? id,
+    String? title,
+    String? description,
+    List<String>? tags,
+    DateTime? timestamp,
+    String? fileName,
+    int? storageSize,
+    bool? isFavorited,
+  });
+
+  Map<String, Object?> toJson() => {
+        MediaFields.id: id,
+        MediaFields.title: title,
+        MediaFields.description: description,
+        MediaFields.tags: tags?.join(','),
+        MediaFields.timestamp: timestamp.toUtc().millisecondsSinceEpoch,
+        MediaFields.fileName: fileName,
+        MediaFields.storageSize: storageSize,
+        MediaFields.isFavorited: isFavorited ? 1 : 0,
+      };
+
+  static Media fromJson(Map<String, Object?> json) {
+    throw UnimplementedError();
+  }
+}

--- a/cogniopenapp/lib/src/database/model/media_type.dart
+++ b/cogniopenapp/lib/src/database/model/media_type.dart
@@ -1,0 +1,5 @@
+enum MediaType {
+  conversation,
+  photo,
+  video,
+}

--- a/cogniopenapp/lib/src/database/model/photo.dart
+++ b/cogniopenapp/lib/src/database/model/photo.dart
@@ -1,0 +1,78 @@
+import 'package:cogniopenapp/src/database/model/media.dart';
+import 'package:cogniopenapp/src/database/model/media_type.dart';
+
+const String tablePhotos = 'photos';
+
+class PhotoFields extends MediaFields {
+  static final List<String> values = [
+    ...MediaFields.values,
+  ];
+}
+
+class Photo extends Media {
+  Photo({
+    int? id,
+    String? title,
+    String? description,
+    List<String>? tags,
+    required DateTime timestamp,
+    required String fileName,
+    required int storageSize,
+    required bool isFavorited,
+  }) : super(
+          id: id,
+          mediaType: MediaType.photo,
+          title: title,
+          description: description,
+          tags: tags,
+          timestamp: timestamp,
+          fileName: fileName,
+          storageSize: storageSize,
+          isFavorited: isFavorited,
+        );
+
+  @override
+  Photo copy({
+    int? id,
+    String? title,
+    String? description,
+    List<String>? tags,
+    DateTime? timestamp,
+    String? fileName,
+    int? storageSize,
+    bool? isFavorited,
+  }) =>
+      Photo(
+        id: id ?? this.id,
+        title: title ?? this.title,
+        description: description ?? this.description,
+        tags: tags ?? this.tags,
+        timestamp: timestamp ?? this.timestamp,
+        fileName: fileName ?? this.fileName,
+        storageSize: storageSize ?? this.storageSize,
+        isFavorited: isFavorited ?? this.isFavorited,
+      );
+
+  @override
+  Map<String, Object?> toJson() {
+    return {
+      ...super.toJson(),
+    };
+  }
+
+  @override
+  static Photo fromJson(Map<String, Object?> json) {
+    return Photo(
+      id: json[MediaFields.id] as int?,
+      title: json[MediaFields.title] as String?,
+      description: json[MediaFields.description] as String?,
+      tags: (json[MediaFields.tags] as String?)?.split(','),
+      timestamp: DateTime.fromMillisecondsSinceEpoch(
+          (json[MediaFields.timestamp] as int),
+          isUtc: true),
+      fileName: json[MediaFields.fileName] as String,
+      storageSize: json[MediaFields.storageSize] as int,
+      isFavorited: json[MediaFields.isFavorited] == 1,
+    );
+  }
+}

--- a/cogniopenapp/lib/src/database/model/video.dart
+++ b/cogniopenapp/lib/src/database/model/video.dart
@@ -1,0 +1,96 @@
+import 'package:cogniopenapp/src/database/model/media.dart';
+import 'package:cogniopenapp/src/database/model/media_type.dart';
+
+const String tableVideos = 'videos';
+
+class VideoFields extends MediaFields {
+  static final List<String> values = [
+    ...MediaFields.values,
+    duration,
+    thumbnail,
+  ];
+
+  static const String duration = 'duration';
+  static const String thumbnail = 'thumbnail';
+}
+
+class Video extends Media {
+  final String duration;
+  final String? thumbnail;
+
+  Video({
+    int? id,
+    String? title,
+    String? description,
+    List<String>? tags,
+    required DateTime timestamp,
+    required String fileName,
+    required int storageSize,
+    required bool isFavorited,
+    required this.duration,
+    this.thumbnail,
+  }) : super(
+          id: id,
+          mediaType: MediaType.video,
+          title: title,
+          description: description,
+          tags: tags,
+          timestamp: timestamp,
+          fileName: fileName,
+          storageSize: storageSize,
+          isFavorited: isFavorited,
+        );
+
+  @override
+  Video copy({
+    int? id,
+    String? title,
+    String? description,
+    List<String>? tags,
+    DateTime? timestamp,
+    String? fileName,
+    int? storageSize,
+    bool? isFavorited,
+    String? duration,
+    String? thumbnail,
+  }) =>
+      Video(
+        id: id ?? this.id,
+        title: title ?? this.title,
+        description: description ?? this.description,
+        tags: tags ?? this.tags,
+        timestamp: timestamp ?? this.timestamp,
+        fileName: fileName ?? this.fileName,
+        storageSize: storageSize ?? this.storageSize,
+        isFavorited: isFavorited ?? this.isFavorited,
+        duration: duration ?? this.duration,
+        thumbnail: thumbnail ?? this.thumbnail,
+      );
+
+  @override
+  Map<String, Object?> toJson() {
+    return {
+      ...super.toJson(),
+      VideoFields.duration: duration,
+      VideoFields.thumbnail: thumbnail,
+    };
+  }
+
+  @override
+  static Video fromJson(Map<String, Object?> json) {
+    return Video(
+      id: json[MediaFields.id] as int?,
+      title: json[MediaFields.title] as String?,
+      description: json[MediaFields.description] as String?,
+      tags: (json[MediaFields.tags] as String?)?.split(','),
+      timestamp: DateTime.fromMillisecondsSinceEpoch(
+        json[MediaFields.timestamp] as int,
+      ),
+      fileName: json[MediaFields.fileName] as String,
+      storageSize: json[MediaFields.storageSize] as int,
+      isFavorited: json[MediaFields.isFavorited] == 1,
+      duration: json[VideoFields.duration] as String,
+      thumbnail: json[VideoFields.thumbnail] as String?,
+    );
+  }
+}

--- a/cogniopenapp/lib/src/database/repository/conversation_repository.dart
+++ b/cogniopenapp/lib/src/database/repository/conversation_repository.dart
@@ -1,0 +1,64 @@
+import 'package:cogniopenapp/src/database/app_database.dart';
+import 'package:cogniopenapp/src/database/model/media.dart';
+import 'package:cogniopenapp/src/database/model/conversation.dart';
+
+class ConversationRepository {
+  static final ConversationRepository instance = ConversationRepository._init();
+
+  ConversationRepository._init();
+
+  Future<Conversation> create(Conversation conversation) async {
+    final db = await AppDatabase.instance.database;
+
+    final id = await db.insert(tableConversations, conversation.toJson());
+
+    return conversation.copy(id: id);
+  }
+
+  Future<int> delete(int id) async {
+    final db = await AppDatabase.instance.database;
+
+    return await db.delete(
+      tableConversations,
+      where: '${MediaFields.id} = ?',
+      whereArgs: [id],
+    );
+  }
+
+  Future<Conversation> read(int id) async {
+    final db = await AppDatabase.instance.database;
+
+    final maps = await db.query(
+      tableConversations,
+      columns: ConversationFields.values,
+      where: '${MediaFields.id} = ?',
+      whereArgs: [id],
+    );
+
+    if (maps.isNotEmpty) {
+      return Conversation.fromJson(maps.first);
+    } else {
+      throw Exception('ID $id not found');
+    }
+  }
+
+  Future<List<Conversation>> readAll() async {
+    final db = await AppDatabase.instance.database;
+
+    const orderBy = '${MediaFields.id} ASC';
+    final result = await db.query(tableConversations, orderBy: orderBy);
+
+    return result.map((json) => Conversation.fromJson(json)).toList();
+  }
+
+  Future<int> update(Conversation conversation) async {
+    final db = await AppDatabase.instance.database;
+
+    return db.update(
+      tableConversations,
+      conversation.toJson(),
+      where: '${MediaFields.id} = ?',
+      whereArgs: [conversation.id],
+    );
+  }
+}

--- a/cogniopenapp/lib/src/database/repository/photo_repository.dart
+++ b/cogniopenapp/lib/src/database/repository/photo_repository.dart
@@ -1,0 +1,64 @@
+import 'package:cogniopenapp/src/database/app_database.dart';
+import 'package:cogniopenapp/src/database/model/media.dart';
+import 'package:cogniopenapp/src/database/model/photo.dart';
+
+class PhotoRepository {
+  static final PhotoRepository instance = PhotoRepository._init();
+
+  PhotoRepository._init();
+
+  Future<Photo> create(Photo photo) async {
+    final db = await AppDatabase.instance.database;
+
+    final id = await db.insert(tablePhotos, photo.toJson());
+
+    return photo.copy(id: id);
+  }
+
+  Future<int> delete(int id) async {
+    final db = await AppDatabase.instance.database;
+
+    return await db.delete(
+      tablePhotos,
+      where: '${MediaFields.id} = ?',
+      whereArgs: [id],
+    );
+  }
+
+  Future<Photo> read(int id) async {
+    final db = await AppDatabase.instance.database;
+
+    final maps = await db.query(
+      tablePhotos,
+      columns: MediaFields.values,
+      where: '${MediaFields.id} = ?',
+      whereArgs: [id],
+    );
+
+    if (maps.isNotEmpty) {
+      return Photo.fromJson(maps.first);
+    } else {
+      throw Exception('ID $id not found');
+    }
+  }
+
+  Future<List<Photo>> readAll() async {
+    final db = await AppDatabase.instance.database;
+
+    const orderBy = '${MediaFields.id} ASC';
+    final result = await db.query(tablePhotos, orderBy: orderBy);
+
+    return result.map((json) => Photo.fromJson(json)).toList();
+  }
+
+  Future<int> update(Photo photo) async {
+    final db = await AppDatabase.instance.database;
+
+    return db.update(
+      tablePhotos,
+      photo.toJson(),
+      where: '${MediaFields.id} = ?',
+      whereArgs: [photo.id],
+    );
+  }
+}

--- a/cogniopenapp/lib/src/database/repository/video_repository.dart
+++ b/cogniopenapp/lib/src/database/repository/video_repository.dart
@@ -1,0 +1,64 @@
+import 'package:cogniopenapp/src/database/app_database.dart';
+import 'package:cogniopenapp/src/database/model/media.dart';
+import 'package:cogniopenapp/src/database/model/video.dart';
+
+class VideoRepository {
+  static final VideoRepository instance = VideoRepository._init();
+
+  VideoRepository._init();
+
+  Future<Video> create(Video video) async {
+    final db = await AppDatabase.instance.database;
+
+    final id = await db.insert(tableVideos, video.toJson());
+
+    return video.copy(id: id);
+  }
+
+  Future<int> delete(int id) async {
+    final db = await AppDatabase.instance.database;
+
+    return await db.delete(
+      tableVideos,
+      where: '${MediaFields.id} = ?',
+      whereArgs: [id],
+    );
+  }
+
+  Future<Video> read(int id) async {
+    final db = await AppDatabase.instance.database;
+
+    final maps = await db.query(
+      tableVideos,
+      columns: VideoFields.values,
+      where: '${MediaFields.id} = ?',
+      whereArgs: [id],
+    );
+
+    if (maps.isNotEmpty) {
+      return Video.fromJson(maps.first);
+    } else {
+      throw Exception('ID $id not found');
+    }
+  }
+
+  Future<List<Video>> readAll() async {
+    final db = await AppDatabase.instance.database;
+
+    const orderBy = '${MediaFields.id} ASC';
+    final result = await db.query(tableVideos, orderBy: orderBy);
+
+    return result.map((json) => Video.fromJson(json)).toList();
+  }
+
+  Future<int> update(Video video) async {
+    final db = await AppDatabase.instance.database;
+
+    return db.update(
+      tableVideos,
+      video.toJson(),
+      where: '${MediaFields.id} = ?',
+      whereArgs: [video.id],
+    );
+  }
+}

--- a/cogniopenapp/lib/src/galleryData.dart
+++ b/cogniopenapp/lib/src/galleryData.dart
@@ -10,6 +10,11 @@ import '../src/conversation.dart';
 import '../main.dart';
 import 'dart:io';
 
+import 'package:cogniopenapp/src/database/model/media.dart' as database_media;
+import 'package:cogniopenapp/src/database/repository/conversation_repository.dart';
+import 'package:cogniopenapp/src/database/repository/photo_repository.dart';
+import 'package:cogniopenapp/src/database/repository/video_repository.dart';
+
 class GalleryData {
   static final GalleryData _instance = GalleryData._internal();
   static late Directory photoDirectory;
@@ -36,6 +41,26 @@ class GalleryData {
     getAllPhotos();
     getAllVideos();
     _setMostRecentVideo();
+    _initializeMedia(); // temporary db testing
+  }
+
+  // temporary db testing:
+  Future<List<database_media.Media>> _initializeMedia() async {
+    final conversations = await ConversationRepository.instance.readAll();
+    final photos = await PhotoRepository.instance.readAll();
+    final videos = await VideoRepository.instance.readAll();
+
+    for (var conversation in conversations) {
+      print(conversation.toJson());
+    }
+    for (var photo in photos) {
+      print(photo.toJson());
+    }
+    for (var video in videos) {
+      print(video.toJson());
+    }
+
+    return [...conversations, ...photos, ...videos];
   }
 
   factory GalleryData() {

--- a/cogniopenapp/pubspec.yaml
+++ b/cogniopenapp/pubspec.yaml
@@ -65,6 +65,7 @@ dependencies:
   aws_kinesis_api: ^2.0.0
   aws_sns_api: ^2.0.0
   aws_s3_api: ^2.0.0
+  sqflite: ^2.3.0
 
   path: ^1.8.3
 


### PR DESCRIPTION
**Work Item** [TASK 335](https://dev.azure.com/ProjectCogniOpen/CogniOpen/_workitems/edit/335) for [USER STORY 334](https://dev.azure.com/ProjectCogniOpen/CogniOpen/_workitems/edit/334)

**Description:** This PR adds sqflite database base code to introduce persistent storage for the application; specifically it does the following:
- Adds the `sqflite` plugin
- Creates the abstract model class `Media` with child model classes (that follow the new `MediaType` enum list) for `Conversation`, `Photo`, and `Video`.
- Creates the repository classes for all of the media types, which are used for database CRUD operations (along with methods to load and unload the database into JSON -- used by `sqflite`.
- Creates the `AppDatabase`, where the database with tables are created.
- Organizes database source files into a new database folder with model and repository subfolders
- Added some _in-progress_ seed data for development / proof of concept.

**Design / Implementation Notes:**
- For now the seed data is used to prove that persistent storage is working. The goal for the next iteration (per the linked work items) is to refactor the `Gallery` class and it's associated classes, which will include retiring the other redundant models (I will be sure to update the new models or the logic to reflect what is needed -- yes this may included editing required fields as well as fields in general). Also, I will add/use actual media for the seed data.
- Most importantly, I designed the database to use 3 tables for the concrete media subclasses and not for the the abstract media superclass. I attempted to have 4 tables (one for Media too) with foreign key references, but it somewhat conflicted with the expectations (JSON methods) for sqflite as well as seemed unnecessary based on how we will be using and searching this data ... and generally added unnecessary complexity with some defects. If you disagree, we can update later, but this was my conclusion. So, to summarize, I implemented `Concrete Table Inheritance (Concrete Inheritance)` rather than `Single Table Inheritance (STI)` nor `Class Table Inheritance (CTI)`

**Usage Notes:** You should wipe the date from the emulated device before running the application to build the database from scratch. Next you should hard reload (`R`) the application to ensure that data is loaded and unloaded properly (persistent storage is working).